### PR TITLE
Enable large twitter cards

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,6 +17,8 @@
 <meta name="twitter:title" content="PyCon AU 2019 | {{ page.title }}" />
 <meta name="twitter:site"  content="@pyconau">
 <meta name="twitter:description" content="{{ description }}" />
+<meta name="twitter:card" content="summary_large_image">
+
 
 {%- if page.card %}
 {% assign card = page.card | prepend: "/static/img/cards/" | prepend: site.url -%}


### PR DESCRIPTION
enables large twitter cards that show content description in addition to the image/title.