### PR TITLE
Adding financial aid link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ navigationLinks:
  - {permalink: '/news/', text: "News"}
  - {permalink: '/speak/', text: "Speak"}
  - {permalink: '/attend/', text: "Attend"}
+ - {permalink: '/assistance/', text: "Financial Aid"}
  - {permalink: '/sponsor/', text: "Sponsor"}
  - {permalink: '/conduct/', text: "Conduct"}
 


### PR DESCRIPTION
At the moment our FinAid page isn't quite so easily discoverable. To avoid the risk that people will not find it, I have added it to the header menu.