### PR TITLE
Add link to ical schedule

### DIFF
--- a/_includes/schedule-day-header.html
+++ b/_includes/schedule-day-header.html
@@ -1,2 +1,3 @@
 <link rel="stylesheet" href="/static/css/schedule.css">
 <h5 class="schedule-nav">Skip to: {% for navday in site.conferenceDays %}{%- if forloop.index0 == dayindex -%}{{navday}}{%-else-%}<a href="/schedule/{{navday | downcase}}">{{navday}}</a> {%-endif %}{% if forloop.last == false%}, {% endif%}{%endfor-%}</h5>
+<p>Download as <a href="/schedule/conference.ics">iCal</a>.</p>


### PR DESCRIPTION

This adds a link to the awesome ical schedule made by @auscompgeek (#115) so it is visible/discoverable.

Screenshot for reference:
![1564697367](https://user-images.githubusercontent.com/9714796/62330736-b3074d00-b4f8-11e9-938a-3b68ddb873ea.png)