### PR TITLE
Add speaker names to iCalendar

### DIFF
--- a/_layouts/schedule_ical.ics
+++ b/_layouts/schedule_ical.ics
@@ -22,7 +22,7 @@ SUMMARY:{{ talk.title | strip | replace: "\\", "\\\\" | replace: newline, "\\n" 
 DTSTART;TZID=Australia/Sydney:{{ day.date | replace: "-", "" }}T{{ time_slot.startTime | replace: ":", "" }}00
 DTEND;TZID=Australia/Sydney:{{ day.date | replace: "-", "" }}T{{ endTime | replace: ":", "" }}00
 UID:{{ talk_id }}@2019.pycon-au.org
-DESCRIPTION:{{ talk.abstract | strip | replace: "\\", "\\\\" | replace: newline, "\\n" | replace: ",", "\\," }}
+DESCRIPTION:Speaker: {{ talk.speakers | map: "name" | join: " and " }}\n\n{{ talk.abstract | strip | replace: "\\", "\\\\" | replace: newline, "\\n" | replace: ",", "\\," }}
 LOCATION:{{ track.title }}
 URL:https://2019.pycon-au.org{{ talk.url }}
 END:VEVENT{% endfor %}{% endfor %}{% endfor %}


### PR DESCRIPTION
Before:

![Screenshot from 2019-08-02 12-01-43](https://user-images.githubusercontent.com/128854/62338863-61bd8480-b51d-11e9-842d-3a45abaef877.png)

After:

![Screenshot from 2019-08-02 12-03-25](https://user-images.githubusercontent.com/128854/62338906-903b5f80-b51d-11e9-838e-0197d7a2db55.png)

Note the additional speaker line which I have highlighted.