### PR TITLE
correct twitter handle

### DIFF
--- a/_talks/992-invited-speaker-2.md
+++ b/_talks/992-invited-speaker-2.md
@@ -10,7 +10,7 @@ recordingconsent: true
 speakers:
     - name: Brandon Rhodes
       avatar: brandon.jpg
-      twitter: brandonrhodes
+      twitter: brandon_rhodes
       biography: |
         Brandon Rhodes has used Python since 1997, because he was stubborn and preferred to use a beautiful language rather than one that anyone had ever heard of. He maintains a few open source amateur astronomy libraries like Skyfield and PyEphem, but is best known for his writing, speaking, and training about how the Python language can be used most effectively. He also loves digital typesetting, backpacking trips to the Grand Canyon, and the Oxford comma.
 


### PR DESCRIPTION
This corrects the twitter handle for Brandon Rhodes: https://twitter.com/brandon_rhodes